### PR TITLE
feat: migrate the existing renovate and default configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
-	"name": "Base Template",
+	"name": "Renovate config",
 
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:1.0.12-bookworm@sha256:eb54c7935538ce8a63092a53d61c95f8cebc19921de2df6bc65dc606d8e5bb1d",

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# base-template
-Template containing basic documentation and structure for all my personal projects in order to avoid copy-pasting
+# Renovate configuration

--- a/default/default.json
+++ b/default/default.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default configuration for use in my personal repositories",
+  "extends": [
+    "config:best-practices",
+    ":maintainLockFilesWeekly",
+    ":rebaseStalePrs",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    ":disableRateLimiting",
+    ":gitSignOff"
+  ],
+  "forkProcessing": "enabled",
+  "labels": ["renovate"],
+  "automergeType": "pr",
+  "commitBodyTable": true,
+  "configMigration": true,
+  "minimumReleaseAge": "0",
+  "rebaseWhen": "behind-base-branch",
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "description": "Require approval for all major version updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Prefix all markdown files updates with 'docs'",
+      "matchFileNames": ["**/*.md"],
+      "semanticCommitType": "docs",
+      "semanticCommitScope": null,
+      "automerge": true
+    },
+    {
+      "description": "Pin Docker images with their SHA256 digest",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchDatasources": ["docker"],
+      "pinDigests": true
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update _VERSION variables in shell scripts",
+      "fileMatch": ["\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s[A-Z_]+?_VERSION=(?<currentValue>.+?)\\s"
+      ]
+    }
+  ]
+}

--- a/default/github.json
+++ b/default/github.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default configuration for use in my GitHub repositories",
+  "extends": [
+    "github>gsuquet/reonvate-config/default",
+    ":assignAndReview(gsuquet)"
+  ],
+  "packageRules": [
+    {
+      "description": "v prefix workaround for GitHub action updates",
+      "matchDepTypes": ["action"],
+      "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update `version:` and `_VERSION:` variables in github workflows",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "\\s+(?:[a-z]-)?version: (?<currentValue>.+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s",
+        "\\s*[A-Z_]+?_VERSION: (?<currentValue>.+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s"
+      ]
+    }
+  ]
+}

--- a/default/gitlab.json
+++ b/default/gitlab.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default configuration for use in my GitLab repositories",
+  "extends": [
+    "github>gsuquet/reonvate-config/default",
+    ":assignAndReview(gabrielsuquet)"
+  ]
+}

--- a/renovate/repo/default.json
+++ b/renovate/repo/default.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default self-hosted runner repository configuration",
+  "packageRules": [
+    {
+      "description": "Update renovate docker image weekly",
+      "extends": ["schedule:weekly"],
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["renovate"]
+    }
+  ]
+}

--- a/renovate/runner/default.json
+++ b/renovate/runner/default.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate self-hosted runner configuration",
+  "autodiscover": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "onboarding": true,
+  "onboardingConfig": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>gsuquet/renovate-config/default"]
+  },
+  "onboardingBranch": "chore/renovate/onboarding",
+  "onboardingCommitMessage": "chore(config): add renovate",
+  "onboardingPrTitle": "chore(renovate): onboarding and configuration",
+  "platformCommit": true,
+  "prCommitsPerRunLimit": 0
+}

--- a/renovate/runner/github.json
+++ b/renovate/runner/github.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate GitHub self-hosted runner configuration",
+  "extends": ["github>gsuquet/renovate-config/renovate/runner"],
+  "autodiscoverFilter": ["gsuquet/*"],
+  "branchPrefix": "gsuquet/renovate/",
+  "dependencyDashboardTitle": "Dependency Dashboard (self-hosted)",
+  "onboardingConfig": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>gsuquet/renovate-config/default:github"]
+  },
+  "onboardingConfigFileName": ".github/renovate.json",
+  "platform": "github"
+}

--- a/renovate/runner/gitlab.json
+++ b/renovate/runner/gitlab.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate GitLab self-hosted runner configuration",
+  "extends": ["github>gsuquet/renovate-config/renovate/runner"],
+  "onboardingConfig": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>gsuquet/renovate-config/default:gitlab"]
+  },
+  "onboardingConfigFileName": ".gitlab/renovate.json",
+  "platform": "gitlab"
+}


### PR DESCRIPTION
# Description

Migrate the existing renovate configuration to this repository (GitHub and GitLab):
- Renovate:  runner and repo
- Default repository configuration